### PR TITLE
Remove javaagent from JAVA_OPTS.

### DIFF
--- a/docker/dev/setenv.sh
+++ b/docker/dev/setenv.sh
@@ -3,4 +3,4 @@
 echo Setting NUXEO_HOME
 export NUXEO_HOME="$CATALINA_BASE/nuxeo-server"
 echo Setting JAVA_OPTS
-export JAVA_OPTS="$JAVA_OPTS -javaagent:$CATALINA_BASE/lib/spring-instrument-4.3.1.RELEASE.jar -Dslf4j.detectLoggerNameMismatch=true -Dlog4j.debug=false -Dnuxeo.home.dir=$NUXEO_HOME -Dnuxeo.log.dir=$NUXEO_HOME/log -Dorg.collectionspace.services.authorities.reset=true"
+export JAVA_OPTS="$JAVA_OPTS -Dslf4j.detectLoggerNameMismatch=true -Dlog4j.debug=false -Dnuxeo.home.dir=$NUXEO_HOME -Dnuxeo.log.dir=$NUXEO_HOME/log -Dorg.collectionspace.services.authorities.reset=true"


### PR DESCRIPTION
This option hasn't been needed since we upgraded to Tomcat 8 in CSpace version 5.0, and it hasn't been set in the CollectionSpace tomcat distribution tarballs since then. The spring-instrument-4.3.1.RELEASE.jar file has now been removed from the master branch, so the presence of this option now causes a tomcat startup error.