### PR TITLE
Fix for failing tests

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -98,6 +98,7 @@ RUN apt-get update && \
       git \
       imagemagick \
       language-pack-en \
+      libharfbuzz0b \
       maven \
       openjdk-${JAVA_VERSION}-jdk-headless \
       openjdk-${JAVA_VERSION}-jre-headless \


### PR DESCRIPTION
This adds the libharfbuzz shared object which is required by libfontmanager in the jdk 25 installation in the container.

See https://collectionspace.atlassian.net/browse/DRYD-2128 +
```
collectionspace@f80369febaa5:/services$ ldd /usr/lib/jvm/java-25-openjdk-amd64/lib/libfontmanager.so 
        linux-vdso.so.1 (0x00007facd1128000)
        libharfbuzz.so.0 => not found
        libfreetype.so.6 => /usr/lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007facd1037000)
        libawt.so => /usr/lib/jvm/java-25-openjdk-amd64/lib/libawt.so (0x00007facd0f3d000)
        libjava.so => /usr/lib/jvm/java-25-openjdk-amd64/lib/libjava.so (0x00007facd0f1a000)
        libjvm.so => not found
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007facd0c78000)
        libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007facd0b52000)
        libgcc_s.so.1 => /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007facd0b24000)
        libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007facd0903000)
        libz.so.1 => /usr/lib/x86_64-linux-gnu/libz.so.1 (0x00007facd08e5000)
        libbz2.so.1.0 => /usr/lib/x86_64-linux-gnu/libbz2.so.1.0 (0x00007facd08d0000)
        libpng16.so.16 => /usr/lib/x86_64-linux-gnu/libpng16.so.16 (0x00007facd0894000)
        libbrotlidec.so.1 => /usr/lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007facd0885000)
        /lib64/ld-linux-x86-64.so.2 (0x00007facd112a000)
        libjvm.so => not found
        libjvm.so => not found
        libbrotlicommon.so.1 => /usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007facd0862000)
```